### PR TITLE
Feat/add integrations to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
       script:
         - bash infrastructure/travis/build.sh
     - stage: integration-tests
-      install: skip
+      language: bash
       services:
         - docker
       scripts:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,12 @@ jobs:
         - docker
       script:
         - bash infrastructure/travis/build.sh
+    - stage: integration-tests
+      install: skip
+      services:
+        - docker
+      scripts:
+        - bash integration-tests.sh
     - stage: deploy
       install:
         - bash ./infrastructure/travis/install-openshift.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,13 @@ jobs:
         - bash infrastructure/travis/build.sh
     - stage: integration-tests
       language: bash
+      env:
+        - DOCKER_COMPOSE_VERSION=2.4
+      before_install:
+        - sudo rm /usr/local/bin/docker-compose
+        - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+        - chmod +x docker-compose
+        - sudo mv docker-compose /usr/local/bin
       services:
         - docker
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ jobs:
       script: bash infrastructure/travis/deploy.sh
 stages:
   - test
+  - integration-tests
   - name: build
     if: (branch = master AND type != pull_request) OR tag IS present
   - name: deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
       language: bash
       services:
         - docker
-      scripts:
+      script:
         - bash integration-tests.sh
     - stage: deploy
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ jobs:
     - stage: integration-tests
       language: bash
       env:
-        - DOCKER_COMPOSE_VERSION=2.4
+        - DOCKER_COMPOSE_VERSION=1.23.2
       before_install:
         - sudo rm /usr/local/bin/docker-compose
         - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "node dist/server.js",
     "dev": "ts-node-dev --no-notify lib/server.ts",
     "format": "prettier --write \"lib/**/*.js\"",
-    "integration": "jest --config ./jest.integration-config.js",
+    "integration": "jest --config ./jest.integration-config.js --detectOpenHandles",
     "integration:watch": "jest --watch --config ./jest.integration-config.js",
     "lint": "eslint 'lib/**/*.{ts,tsx}'",
     "build": "npm run lint && npm run unit && npm run build-ts",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "node dist/server.js",
     "dev": "ts-node-dev --no-notify lib/server.ts",
     "format": "prettier --write \"lib/**/*.js\"",
-    "integration": "bash integration-tests.sh",
+    "integration": "jest --config ./jest.integration-config.js",
     "integration:watch": "jest --watch --config ./jest.integration-config.js",
     "lint": "eslint 'lib/**/*.{ts,tsx}'",
     "build": "npm run lint && npm run unit && npm run build-ts",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "node dist/server.js",
     "dev": "ts-node-dev --no-notify lib/server.ts",
     "format": "prettier --write \"lib/**/*.js\"",
-    "integration": "jest --config ./jest.integration-config.js",
+    "integration": "bash integration-tests.sh",
     "integration:watch": "jest --watch --config ./jest.integration-config.js",
     "lint": "eslint 'lib/**/*.{ts,tsx}'",
     "build": "npm run lint && npm run unit && npm run build-ts",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "node dist/server.js",
     "dev": "ts-node-dev --no-notify lib/server.ts",
     "format": "prettier --write \"lib/**/*.js\"",
-    "integration": "jest --config ./jest.integration-config.js --detectOpenHandles",
+    "integration": "jest --config ./jest.integration-config.js --forceExit",
     "integration:watch": "jest --watch --config ./jest.integration-config.js",
     "lint": "eslint 'lib/**/*.{ts,tsx}'",
     "build": "npm run lint && npm run unit && npm run build-ts",


### PR DESCRIPTION
**Ticket:** [#51](https://trello.com/c/vHmkDSD9/51-add-integration-tests-to-travis)

**Intent:**

Run integration tests on every pull request. Uses the slowest possible approach, ends up taking approximately 2 min 44 sec.

This could possibly be optimized in the future. For now this is considered good enough.

Another later optimization could be to debug the tests with --detectOpenHandles. To stop using force exit.

lib/server.ts:52:10
    > 52 |   cache: new RedisCache({