### PR TITLE
feat: semantic release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -2,7 +2,6 @@
     "plugins": [
         "@semantic-release/commit-analyzer",
         "@semantic-release/release-notes-generator",
-        "@semantic-release/github",
-        "@semantic-release/git"
+        "@semantic-release/github"
     ]
 }

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,8 @@
+{
+    "plugins": [
+        "@semantic-release/commit-analyzer",
+        "@semantic-release/release-notes-generator",
+        "@semantic-release/github",
+        "@semantic-release/git"
+    ]
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,8 @@ stages:
     if: (branch = master AND type != pull_request) OR tag IS present
   - name: deploy
     if: (branch = master AND type != pull_request) OR tag IS present
+  - name: create-release-notes
+    if: branch = master
 env:
   global:
     - secure: DOYKVqaObpLYa7iaEPykCuHdXeUw2pHnSZL/6fylLKHDsCoMfvFvW939ubEQebsaeU4HHLMVJ0FT6gpQCRRNnxkp+BPypQMUnkcV6OzAKXoM7OSoaq2RzbAXMQXvaF5Jd82j2d3j1Dx2DF0bGdv5KTxNaqL4hqW1u0z7FIpD7EiTazC2NzSVharpp074t5vsTBBor24GY2QXJ9449gILP0Qw8/JImybmBJ5TtINyREWC+xmTkmjYG+i8zdQxLRW1nKIiWnH82ZwrJtrWS6DI1O1ZOtcCnSlPhlSxVLYgvk76BZr3rNrdgRs7QQ9nAI0XOzc+ao5+3PBy+pGIBGF8CO98qvQfRbDI24BO3Da0F6Rn9IzHd9zX42xMk5DySBR2CrXgCzoHPb1mor+rM6qsBG8O5zo9+AcK1q3sllzHF3o9hHZKQHB5audvdUehp+I5ryv2EbkcUXquPGRgpSHsvTGrDRLQwM9Jkf65SQbbzN9TpCEu7iZy4ysq/LiRKb+ebppsPR/qNrTXH1IDxTnAeUzpnCxc02v7/DnadfD7dLL9qQ2ue2ksrDOlqk79QeGogNvj6dsUySvIqPYEIF3T52u1M7VElGRNjmzox+9d1XcYcwCnRo0djLyRCn9xwMD3KkZQFhsFLGzKeM2TAW4mmJmsn1Od9QnHRrw0kiwXzvk=

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,8 @@ jobs:
       script: bash infrastructure/travis/deploy.sh
     - stage: create-release-notes
       language: node_js
-      script: npx semantic-release
+      install: skip
+      script: npx semantic-release --branch feat/semantic-release
 stages:
   - test
   - integration-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ stages:
   - name: deploy
     if: (branch = master AND type != pull_request) OR tag IS present
   - name: create-release-notes
-    if: branch = master
+    if:  branch = master AND type != pull_request
 env:
   global:
     - secure: DOYKVqaObpLYa7iaEPykCuHdXeUw2pHnSZL/6fylLKHDsCoMfvFvW939ubEQebsaeU4HHLMVJ0FT6gpQCRRNnxkp+BPypQMUnkcV6OzAKXoM7OSoaq2RzbAXMQXvaF5Jd82j2d3j1Dx2DF0bGdv5KTxNaqL4hqW1u0z7FIpD7EiTazC2NzSVharpp074t5vsTBBor24GY2QXJ9449gILP0Qw8/JImybmBJ5TtINyREWC+xmTkmjYG+i8zdQxLRW1nKIiWnH82ZwrJtrWS6DI1O1ZOtcCnSlPhlSxVLYgvk76BZr3rNrdgRs7QQ9nAI0XOzc+ao5+3PBy+pGIBGF8CO98qvQfRbDI24BO3Da0F6Rn9IzHd9zX42xMk5DySBR2CrXgCzoHPb1mor+rM6qsBG8O5zo9+AcK1q3sllzHF3o9hHZKQHB5audvdUehp+I5ryv2EbkcUXquPGRgpSHsvTGrDRLQwM9Jkf65SQbbzN9TpCEu7iZy4ysq/LiRKb+ebppsPR/qNrTXH1IDxTnAeUzpnCxc02v7/DnadfD7dLL9qQ2ue2ksrDOlqk79QeGogNvj6dsUySvIqPYEIF3T52u1M7VElGRNjmzox+9d1XcYcwCnRo0djLyRCn9xwMD3KkZQFhsFLGzKeM2TAW4mmJmsn1Od9QnHRrw0kiwXzvk=

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,8 @@ jobs:
       script: bash infrastructure/travis/deploy.sh
     - stage: create-release-notes
       language: node_js
-      install: skip
+      install:
+        - npm i @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/github
       script: npx semantic-release --branch feat/semantic-release
 stages:
   - test

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
       language: node_js
       install:
         - npm i @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/github
-      script: npx semantic-release --branch feat/semantic-release
+      script: npx semantic-release
 stages:
   - test
   - integration-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
         - bash ./infrastructure/travis/install-openshift.sh
         - export PATH=$PATH:/tmp/openshift
       script: bash infrastructure/travis/deploy.sh
-    - stage: create-release-notes
+    - stage: create-release
       language: node_js
       install:
         - npm i @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/github
@@ -44,7 +44,7 @@ stages:
     if: (branch = master AND type != pull_request) OR tag IS present
   - name: deploy
     if: (branch = master AND type != pull_request) OR tag IS present
-  - name: create-release-notes
+  - name: create-release
     if:  branch = master AND type != pull_request
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ jobs:
         - bash ./infrastructure/travis/install-openshift.sh
         - export PATH=$PATH:/tmp/openshift
       script: bash infrastructure/travis/deploy.sh
+    - stage: create-release-notes
+      language: node_js
+      script: npx semantic-release
 stages:
   - test
   - integration-tests

--- a/package.json
+++ b/package.json
@@ -21,14 +21,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Iteam1337/myskills-api.git"
+    "url": "git+https://github.com/JobtechSwe/myskills-api.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/Iteam1337/myskills-api/issues"
+    "url": "https://github.com/JobtechSwe/myskills-api/issues"
   },
-  "homepage": "https://github.com/Iteam1337/myskills-api#readme",
+  "homepage": "https://github.com/JobtechSwe/myskills-api#readme",
   "dependencies": {
     "@mydata/client": "^0.22.3",
     "apollo-cache-inmemory": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "myskills-api",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "myskills-api",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
**Ticket:** [#53](https://trello.com/c/rEoxeTNq/53-generate-changelog-from-semantic-commits)

**Intent:**
This adds semantic release notes to github after a 'meaningful' commit was made. Thus, e.g chores will not trigger it, this is of course should be possible to change.
it also adds a commit in every PR/issue that has been included in the release.

This uses my personal github key to access github...It doesnt seem to be another way for now.


Examples of the output can be found in https://github.com/JobtechSwe/myskills-api/releases
