### PR TITLE
ci: 🎡 use tls for api route

### DIFF
--- a/infrastructure/openshift/README.md
+++ b/infrastructure/openshift/README.md
@@ -46,6 +46,13 @@ oc create secret generic redis-ci-password --from-literal=database-password=crea
 oc create secret generic redis-test-password --from-literal=database-password=create-a-secret-Secret
 ```
 
+- Create a secret with the TLS certificate
+
+```bash
+# Replace the path below with a path to your TLS certificate file
+oc create secret generic tls --from-file=/tmp/jtech.se.crt
+```
+
 #### Prepare dependencies
 
 - Create PVC for Redis (this is done separately so that you can teardown your environment and keep the data)

--- a/infrastructure/openshift/ci/api-DeploymentConfig.yml
+++ b/infrastructure/openshift/ci/api-DeploymentConfig.yml
@@ -27,7 +27,7 @@ spec:
       containers:
         - env:
             - name: DOMAIN
-              value: "http://api.myskills-ci.dev.services.jtech.se"
+              value: "https://api-myskills-ci.dev.services.jtech.se"
             - name: PORT
               value: "3000"
             - name: REDIS_API_HOST

--- a/infrastructure/openshift/ci/api-Route.yml
+++ b/infrastructure/openshift/ci/api-Route.yml
@@ -5,7 +5,7 @@ metadata:
     app: ci
   name: api-ci
 spec:
-  host: api.myskills-ci.dev.services.jtech.se
+  host: api-myskills-ci.dev.services.jtech.se
   port:
     targetPort: http
   to:
@@ -13,3 +13,9 @@ spec:
     name: api-ci
     weight: 100
   wildcardPolicy: None
+  tls:
+    valueFrom:
+      secretKeyRef:
+        key: jtech.se.crt
+        name: tls
+    termination: edge

--- a/infrastructure/openshift/ci/redis-Service.yml
+++ b/infrastructure/openshift/ci/redis-Service.yml
@@ -11,6 +11,5 @@ spec:
       protocol: TCP
       targetPort: 6379
   selector:
-    app: ci
     name: redis-ci
   type: ClusterIP


### PR DESCRIPTION

**Ticket:** [#https://trello.com/c/uC5pZ0vL/64-add-https-to-web-and-api](https://trello.com/c/uC5pZ0vL/64-add-https-to-web-and-api)

**Intent:**
using api-myskills-ci because api.myskills-ci does not work with
certificate we use