### PR TITLE
fix(taxonomy): county type is now region

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -415,7 +415,7 @@
         "interfaces": null,
         "enumValues": [
           {
-            "name": "COUNTY",
+            "name": "REGION",
             "description": "",
             "isDeprecated": false,
             "deprecationReason": null

--- a/lib/__generated__/myskills.d.ts
+++ b/lib/__generated__/myskills.d.ts
@@ -46,7 +46,7 @@ export enum Language {
 }
 
 export enum TaxonomyType {
-  County = 'COUNTY',
+  Region = 'REGION',
   EducationField_1 = 'EDUCATION_FIELD_1',
   EducationField_2 = 'EDUCATION_FIELD_2',
   EducationField_3 = 'EDUCATION_FIELD_3',

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -28,7 +28,7 @@ const custom = {
     },
   },
   TaxonomyType: {
-    COUNTY: 'county',
+    REGION: 'region',
     EDUCATION_FIELD_1: 'sun-education-field-1',
     EDUCATION_FIELD_2: 'sun-education-field-2',
     EDUCATION_FIELD_3: 'sun-education-field-3',

--- a/lib/graphql/types/taxonomy.ts
+++ b/lib/graphql/types/taxonomy.ts
@@ -2,7 +2,7 @@ import { gql } from 'apollo-server-express'
 
 export const typeDefs = gql`
   enum TaxonomyType {
-    COUNTY
+    REGION
     EDUCATION_FIELD_1
     EDUCATION_FIELD_2
     EDUCATION_FIELD_3

--- a/test/integration/__fixtures__/taxonomy.ts
+++ b/test/integration/__fixtures__/taxonomy.ts
@@ -30,7 +30,7 @@ export const taxonomy = {
       term: 'Bred, generell utbildning',
       type: 'sun-education-field-2',
     },
-    { taxonomyId: 'CifL_Rzy_Mku', term: 'Stockholms län', type: 'county' },
+    { taxonomyId: 'CifL_Rzy_Mku', term: 'Stockholms län', type: 'region' },
     { taxonomyId: 'kTtK_3Y3_Kha', term: 'Afghanistan', type: 'country' },
     {
       taxonomyId: 'PFZr_Syz_cUq',
@@ -96,7 +96,7 @@ export const skill = {
   total: 5514,
 }
 
-export const county = {
+export const region = {
   search: {
     limit: 10,
     offset: 0,
@@ -106,52 +106,52 @@ export const county = {
     {
       taxonomyId: 'CifL_Rzy_Mku',
       term: 'Stockholms län',
-      type: 'county',
+      type: 'region',
     },
     {
       taxonomyId: 'zBon_eET_fFU',
       term: 'Uppsala län',
-      type: 'county',
+      type: 'region',
     },
     {
       taxonomyId: 's93u_BEb_sx2',
       term: 'Södermanlands län',
-      type: 'county',
+      type: 'region',
     },
     {
       taxonomyId: 'oLT3_Q9p_3nn',
       term: 'Östergötlands län',
-      type: 'county',
+      type: 'region',
     },
     {
       taxonomyId: 'MtbE_xWT_eMi',
       term: 'Jönköpings län',
-      type: 'county',
+      type: 'region',
     },
     {
       taxonomyId: 'tF3y_MF9_h5G',
       term: 'Kronobergs län',
-      type: 'county',
+      type: 'region',
     },
     {
       taxonomyId: '9QUH_2bb_6Np',
       term: 'Kalmar län',
-      type: 'county',
+      type: 'region',
     },
     {
       taxonomyId: 'K8iD_VQv_2BA',
       term: 'Gotlands län',
-      type: 'county',
+      type: 'region',
     },
     {
       taxonomyId: 'DQZd_uYs_oKb',
       term: 'Blekinge län',
-      type: 'county',
+      type: 'region',
     },
     {
       taxonomyId: 'CaRE_1nn_cSU',
       term: 'Skåne län',
-      type: 'county',
+      type: 'region',
     },
   ],
 }

--- a/test/integration/taxonomy.spec.ts
+++ b/test/integration/taxonomy.spec.ts
@@ -75,7 +75,7 @@ describe('taxonomy', () => {
 
   it.each`
     taxonomyType           | fixture
-    ${'COUNTY'}            | ${taxonomyFixture.county}
+    ${'REGION'}            | ${taxonomyFixture.region}
     ${'EDUCATION_FIELD_1'} | ${taxonomyFixture.educationField1}
     ${'EDUCATION_FIELD_2'} | ${taxonomyFixture.educationField2}
     ${'EDUCATION_FIELD_3'} | ${taxonomyFixture.educationField3}


### PR DESCRIPTION
**Ticket:** [#70](https://trello.com/c/IkBLflwr/70-taxonomy-has-changed-from-county-to-region)

**Intent:**
County has suddenly changed type in jobtech taxonomy (https://github.com/JobtechSwe/sokannonser-api/commit/30f932e4c6857810326de4693d37f7983d72def2) and is now called "region".
We need to adapt these changes.
