### PR TITLE
fix: 🐛 config for semantic-release-docker

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,22 +3,18 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     "@semantic-release/github",
-    "semantic-release-docker",
+    [
+      "semantic-release-docker",
+      {
+        "registryUrl": "docker.io",
+        "name": "jobtechswe/myskills-api"
+      }
+    ],
     [
       "@semantic-release/exec",
       {
         "publishCmd": "./infrastructure/travis/deploy.sh ${nextRelease.version}"
       }
     ]
-  ],
-  "release": {
-    "verifyConditions": {
-      "path": "semantic-release-docker",
-      "registryUrl": "docker.io"
-    },
-    "publish": {
-      "path": "semantic-release-docker",
-      "name": "jobtechswe/myskills-api"
-    }
-  }
+  ]
 }


### PR DESCRIPTION
**Ticket:** [#https://trello.com/c/xv3pDDqt/104-investigate-why-semantic-release-docker-doesnt-push-the-image-to-dockerhub](https://trello.com/c/xv3pDDqt/104-investigate-why-semantic-release-docker-doesnt-push-the-image-to-dockerhub)

**Intent:**
- the README for that repo is b0rked. 
- did some investigation to find the correct way to config it
