### PR TITLE
fix: mitigate changes in taxonomy api

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       timeout: 5s
       retries: 5
   mydata-operator:
-    image: jobtechswe/mydata-operator:latest
+    image: jobtechswe/mydata-operator:0.25.2
     command: >
       bash -c "npm run migrate up
       && npm start"
@@ -93,7 +93,7 @@ services:
         condition: service_started
 
   mydata-app: #This replaces the phone app in the normal flow.
-    image: jobtechswe/mydata-app
+    image: jobtechswe/mydata-app:0.25.3
     environment:
       - OPERATOR_URL=http://mydata-operator:4000/api
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       timeout: 5s
       retries: 5
   mydata-operator:
-    image: jobtechswe/mydata-operator:0.25.2
+    image: jobtechswe/mydata-operator:latest-tag
     command: >
       bash -c "npm run migrate up
       && npm start"
@@ -93,7 +93,7 @@ services:
         condition: service_started
 
   mydata-app: #This replaces the phone app in the normal flow.
-    image: jobtechswe/mydata-app:0.25.3
+    image: jobtechswe/mydata-app:latest-tag
     environment:
       - OPERATOR_URL=http://mydata-operator:4000/api
     ports:

--- a/lib/graphql/resolvers/queries/__tests__/taxonomy.spec.ts
+++ b/lib/graphql/resolvers/queries/__tests__/taxonomy.spec.ts
@@ -4,6 +4,7 @@ import { QueryTaxonomyArgs } from '../../../../__generated__/myskills'
 
 beforeEach(() => {
   ;(ctx.dataSources.taxonomyAPI.getData as jest.Mock).mockResolvedValue({
+    total: { value: 123 },
     result: [
       {
         conceptId: '123',
@@ -66,6 +67,8 @@ test('returnass formted result', async () => {
         taxonomyId: '456',
       },
     ],
+    search: undefined,
+    total: 123,
   })
 })
 

--- a/lib/graphql/resolvers/queries/taxonomy.ts
+++ b/lib/graphql/resolvers/queries/taxonomy.ts
@@ -21,7 +21,7 @@ interface AfTaxonomyResponse {
     offset: number
     limit: number
   }
-  total: number
+  total: { value: number }
   result: [AfTaxonomyResult]
 }
 
@@ -37,8 +37,11 @@ export const taxonomy: QueryResolvers['taxonomy'] = async (
 
   try {
     const data = await taxonomyAPI.getData<AfTaxonomyResponse>(taxonomyQuery)
+    const total = data.total.value
+
     return {
-      ...data,
+      total,
+      search: data.search,
       result: data.result.map(x => ({
         taxonomyId: x.conceptId,
         ...x,

--- a/test/integration/__fixtures__/taxonomy.ts
+++ b/test/integration/__fixtures__/taxonomy.ts
@@ -44,7 +44,7 @@ export const taxonomy = {
     },
   ],
   search: { limit: 10, offset: 0 },
-  total: 12495,
+  total: 10000,
 }
 
 export const skill = {


### PR DESCRIPTION
Taxonomy API has changed, this broke our api (and the integration tests)

Also pinning mydata-version numbers for what seems to work - latest-tag (lets see if it works better)

**Intent:**

**How to test <!--- (optional) -->:**

- [ ] I've written tests for the code. <!---or have a good reason for not writing tests: -->
